### PR TITLE
update example of using babel from scripts

### DIFF
--- a/source/_posts/20180226-npm-authoring.md
+++ b/source/_posts/20180226-npm-authoring.md
@@ -115,8 +115,8 @@ See this example, where all scripts do the same, using global modules, local pat
     {
         "scripts": {
 
-            // using babel as a global module,
-            // exits with an error if the host hasn't installed babel as global
+            // using babel as a global module or local dependency,
+            // exits with an error if the host hasn't installed depdencies or installed babel as global
             "babel": "babel src --out dist",
 
             // using babel as a local dependency


### PR DESCRIPTION
`./node_modules/.bin/` is added to the `PATH` when running an npm script, so you can reference utilities installed as dev dependencies that way, also